### PR TITLE
Add strict option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,14 @@ Add the following configuration to `coffeelint.json`:
 Configuration
 -------------
 
-There are currently no configuration options.
+**strict**: If false, single-expression functions that spans multiple lines are
+allowed.
+
+Example:
+
+```json
+"no_implicit_returns": {
+  "module": "coffeelint-no-implicit-returns",
+  "strict": false
+}
+```

--- a/index.coffee
+++ b/index.coffee
@@ -2,6 +2,7 @@ module.exports = class NoImplicitReturns
 
   rule:
     name: 'no_implicit_returns'
+    strict: true
     level: 'error'
     message: 'Explicit return required for multi-line function'
     description: 'Checks for explicit returns in multi-line functions'
@@ -43,7 +44,8 @@ module.exports = class NoImplicitReturns
           level: 'warn'
           lineNumber: firstLine
           lineNumberEnd: firstLine
-      if firstLine != lastLine and not isPureStatement and firstLine != lastExprLine
+      isStrict = astApi.config[@rule.name].strict
+      if isStrict and firstLine != lastLine and not isPureStatement and firstLine != lastExprLine
         # Single-expression function that spans multiple lines with a leading newline.
         @errors.push astApi.createError
           message: 'Remove leading newline or add explicit return'


### PR DESCRIPTION
This option has a default value of true which is compatible with the current
behavior. If set to false, single-expression functions that spans multiple lines
are allowed.